### PR TITLE
refactor: unitテストのjob修正

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11"]
     
     steps:
       - name: Checkout code
@@ -78,7 +78,6 @@ jobs:
             
       - name: Upload coverage reports
         uses: codecov/codecov-action@v4
-        if: matrix.python-version == '3.11'
         with:
           file: ./coverage.xml
           flags: unittests
@@ -88,25 +87,25 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-${{ matrix.python-version }}
+          name: test-results-python-3.11
           path: |
             test-results.xml
             htmlcov/
             coverage.xml
             
       - name: Comment PR with coverage
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.11' && !github.event.pull_request.head.repo.fork
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-xml-coverage-path: ./coverage.xml
           junitxml-path: ./test-results.xml
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Coverage Report (Python ${{ matrix.python-version }})"
+          title: "Coverage Report (Python 3.11)"
           badge-title: "Coverage"
         continue-on-error: true
         
       - name: Coverage Summary (fallback)
-        if: always() && matrix.python-version == '3.11'
+        if: always()
         run: |
           echo "## 📊 Test & Coverage Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- pytestを実行するpythonのバージョンを3.11のみに修正

## PR概要

### **変更内容の要約**
<!-- このPRで何を変更したかを簡潔に説明してください -->

### **変更の種類**
<!-- 該当するものにチェックを入れてください -->
- [ ]  新機能追加
- [ ]  テスト追加・改善
- [ ]  バグ修正
- [x]  リファクタリング
- [ ]  ドキュメント更新
- [x]  設定・ツール変更
- [ ]  パフォーマンス改善
- [ ]  作業中（WIP）

---

## 変更詳細

### **実装した機能・修正内容**
<!-- 具体的に何を実装・修正したかを詳しく説明してください -->
CIで複数バージョンのpythonでunitテストを実装していたのを3.11のみに修正

### **技術的な変更点**
<!-- アーキテクチャや技術的な変更があれば記載してください -->
特になし

### **テスト内容**
<!-- どのようなテストを追加・実行したかを記載してください -->
- [x] 単体テスト
- [ ] 統合テスト
- [ ] E2Eテスト（Playwright）
- [ ] 手動テスト

---

## 関連Issue・タスク

### **関連Issue**
<!-- 関連するIssueがあれば記載してください -->
- 関連Issue: #123
- 関連Issue: #456

## 注意事項・制約
特になし

## その他・コメント

<!-- その他、レビュアーに伝えたいことがあれば記載してください -->
