### PR TITLE
Bugfix/issue 8 invalid pagination

### DIFF
--- a/src/ui/src/app/files/page.tsx
+++ b/src/ui/src/app/files/page.tsx
@@ -33,7 +33,15 @@ export default function FilesPage() {
       // APIレスポンスのページ番号とローカル状態の整合性チェック
       if (response.page !== page) {
         console.warn(`Page mismatch: requested ${page}, got ${response.page}`);
-        setCurrentPage(response.page);
+        // APIから返されたページ番号が要求したページ番号と異なる場合は、
+        // 要求したページ番号が有効な範囲内であれば、それを維持する
+        const maxPage = Math.ceil(response.total_count / itemsPerPage);
+        if (page >= 1 && page <= maxPage) {
+          // 再度同じページを要求
+          const retryResponse = await api.getFileList(page, itemsPerPage);
+          setFiles(retryResponse);
+          return;
+        }
       }
       
       setFiles(response);


### PR DESCRIPTION
## PR概要

### **変更内容の要約**
<!-- このPRで何を変更したかを簡潔に説明してください -->

### **変更の種類**
<!-- 該当するものにチェックを入れてください -->
- [ ]  新機能追加
- [ ]  テスト追加・改善
- [x]  バグ修正
- [ ]  リファクタリング
- [ ]  ドキュメント更新
- [ ]  設定・ツール変更
- [ ]  パフォーマンス改善
- [ ]  作業中（WIP）

---

## 変更詳細

### **実装した機能・修正内容**
<!-- 具体的に何を実装・修正したかを詳しく説明してください -->
ファイル一覧画面のページネーションにおいて、最後のページから「前へ」ボタンを連続して押下した際に、
予期せず1ページ目にスキップしてしまう問題を修正。

1. APIから異なるページ番号が返された場合でも、要求したページ番号が有効な範囲内であれば、そのページを維持
2. 必要な場合のみ再度同じページを要求し、ローカルの状態を保持
3. ユーザーの意図したページ遷移（例：14 → 13 → 12 → 11 → 10 → 9）が正しく維持される

### **技術的な変更点**
<!-- アーキテクチャや技術的な変更があれば記載してください -->

### **テスト内容**
<!-- どのようなテストを追加・実行したかを記載してください -->
- [ ] 単体テスト
- [ ] 統合テスト
- [ ] E2Eテスト（Playwright）
- [x] 手動テスト

---

## 関連Issue・タスク

### **関連Issue**
<!-- 関連するIssueがあれば記載してください -->
- 関連Issue: #123
- 関連Issue: #456

## 注意事項・制約


## その他・コメント
フロント側も単体テストを導入する
<!-- その他、レビュアーに伝えたいことがあれば記載してください -->
